### PR TITLE
Bump ember-composable-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.1.2",
     "ember-cli-htmlbars": "^3.0.0",
-    "ember-composable-helpers": "^2.0.2",
+    "ember-composable-helpers": "^3.1.1",
     "ember-math-helpers": "^2.1.0",
     "ember-truth-helpers": "^2.0.0",
     "ember-lodash": "^4.19.4"


### PR DESCRIPTION
`ember-composable-helpers` < 3.x defines a custom `array` helpers. Since ember version 3.8.0, ember provides this out of the box. Upgrading the kaleidos project's ember version from 3.16.4 to 3.17.1 somehow brings up this conflict. Bumping `ember-composable-helpers`  to a version that no longer contains this helper, solves the issue.
```
Error: Assertion Failed: You attempted to overwrite the built-in helper "array" which is not allowed. Please rename the helper.
```
References:
- [PR removing array helper](https://github.com/DockYard/ember-composable-helpers/pull/321)
- [recent Stackoverflow issue](https://stackoverflow.com/questions/60746799/error-you-attempted-to-overwrite-the-built-in-helper-array-where-is-this-com)