### PR TITLE
Replace helpers "contains" to "includes"

### DIFF
--- a/addon/templates/components/data-table-content-body.hbs
+++ b/addon/templates/components/data-table-content-body.hbs
@@ -3,7 +3,7 @@
 {{else}}
   {{#if content}}
     {{#each wrappedItems as |wrapper index|}}
-      <tr role="button" class="{{if (contains wrapper.item data-table.selection) "selected"}} {{if onClickRow "clickable"}}" onclick={{action (optional onClickRow) wrapper.item}}>
+      <tr role="button" class="{{if (includes wrapper.item data-table.selection) "selected"}} {{if onClickRow "clickable"}}" onclick={{action (optional onClickRow) wrapper.item}}>
         {{#if enableSelection}}
           <td class="center">
             {{input type="checkbox" checked=wrapper.isSelected click=(action "updateSelection" wrapper)}}


### PR DESCRIPTION
This is literally just replacing the 2 words by each other. Functionality wise nothing changes. It will remove the deprecation warning in console though.
Ref: https://github.com/DockYard/ember-composable-helpers/pull/379