### PR TITLE
Treeshake unused Lodash functions

### DIFF
--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -1,6 +1,8 @@
 /*jshint unused:false */
+/* eslint-disable ember/no-new-mixins */
+
 import Mixin from '@ember/object/mixin';
-import _ from 'lodash';
+import merge from 'lodash/merge';
 
 export default Mixin.create({
   queryParams: {
@@ -22,7 +24,7 @@ export default Mixin.create({
     };
     // TODO: sending an empty filter param to backend returns []
     if (params.filter) { options['filter'] = params.filter; }
-     _.merge(options, this.mergeQueryOptions(params));
+    merge(options, this.mergeQueryOptions(params));
     return this.get('store').query(this.get('modelName'), options);
   },
   actions: {

--- a/package.json
+++ b/package.json
@@ -27,12 +27,13 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "ember-auto-import": "^1.6.0",
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-composable-helpers": "^4.3.0",
-    "ember-lodash": "^4.19.4",
     "ember-math-helpers": "^2.1.0",
-    "ember-truth-helpers": "^2.0.0"
+    "ember-truth-helpers": "^2.0.0",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@ember/jquery": "^0.6.0",
@@ -41,7 +42,6 @@
     "@glimmer/tracking": "^1.0.1",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
-    "ember-auto-import": "^1.6.0",
     "ember-cli": "~3.21.2",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-inject-live-reload": "^2.0.2",

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -1,12 +1,41 @@
-import EmberObject from '@ember/object';
-import RouteMixin from 'ember-data-table/mixins/route';
-import { module, test } from 'qunit';
+/* eslint-disable ember/no-new-mixins,ember/no-mixins */
 
-module('Unit | Mixin | route', function() {
-  // Replace this with your real tests.
-  test('it works', function(assert) {
-    let RouteObject = EmberObject.extend(RouteMixin);
-    let subject = RouteObject.create();
-    assert.ok(subject);
+import EmberObject from "@ember/object";
+import RouteMixin from "ember-data-table/mixins/route";
+import { module, test } from "qunit";
+
+module("Unit | Mixin | route", function () {
+  test("it (deep) merges the response of mergeQueryOptions method with the query param options", function (assert) {
+    assert.expect(2);
+
+    let RouteObject = EmberObject.extend(RouteMixin, {
+      modelName: "test",
+      mergeQueryOptions() {
+        return {
+          foo: "bar",
+          page: {
+            size: 5,
+          },
+        };
+      },
+    });
+
+    let mockStore = {
+      query: (modelName, queryOptions) => {
+        assert.strictEqual(modelName, "test");
+        assert.deepEqual(queryOptions, {
+          sort: "name",
+          page: {
+            size: 5,
+            number: 0,
+          },
+          foo: "bar",
+        });
+      },
+    };
+
+    let mockRoute = RouteObject.create();
+    mockRoute.store = mockStore;
+    mockRoute.model({ sort: "name", page: 0, size: 20 });
   });
 });


### PR DESCRIPTION
This replaces `ember-lodash` with ember-auto-import and the "real" Lodash package which makes it possible to treeshake unused  utils. The final bundle size is reduced by about 40KB (gzipped).

Some build size comparisons of the dummy app:

```
current master branch:
 - dist/assets/vendor-6d26569839d36698b0675756572ea562.js: 1.11 MB (257.84 KB gzipped)

after removing ember-lodash:
 - dist/assets/vendor-82c46dd5e373e06c8dcc397c8d1d6d57.js: 839.02 KB (210.17 KB gzipped)

ember-auto-import + tree shaking:
 - dist/assets/vendor-30d314c1f136ed7f35ab0ef8b7305681.js: 856.35 KB (214.43 KB gzipped)
```

Closes #28.